### PR TITLE
Generalize Region Use in EKS on EC2/Fargate Recipes

### DIFF
--- a/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
@@ -42,17 +42,12 @@ You can either use an existing EKS cluster or create one using [cluster-config.y
 
 This template will create a new cluster with two EC2 `t2.large` nodes. 
 
-Edit the template file and set your region to one of the available regions for AMP:
+Edit the template file and set `<YOUR_REGION>` to one of the
+[supported regions for AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html#AMP-supported-Regions).
 
-* `us-east-1`
-* `us-east-2`
-* `us-west-2`
-* `eu-central-1`
-* `eu-west-1`
-
-Make sure to overwrite this region in your session, for example in bash:
+Make sure to overwrite `<YOUR_REGION>` in your session, for example in bash:
 ```
-export AWS_DEFAULT_REGION=eu-west-1
+export AWS_DEFAULT_REGION=<YOUR_REGION>
 ```
 
 Create your cluster using the following command.
@@ -69,7 +64,7 @@ You can use the following command to create a new ECR registry in your account.
 aws ecr create-repository \
     --repository-name prometheus-sample-app \
     --image-scanning-configuration scanOnPush=true \
-    --region eu-west-1
+    --region <YOUR_REGION>
 ```
 
 ### Set up AMP 
@@ -101,7 +96,7 @@ You can remove this from the re-label configurations if you want to scrape a dif
 
 Use the following steps to edit the downloaded file for your environment:
 
-1\. Replace `<REGION>` with your current region. 
+1\. Replace `<YOUR_REGION>` with your current region. 
 
 2\. Replace `<YOUR_ENDPOINT>` with the remote write URL of your workspace.
 

--- a/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
@@ -38,7 +38,7 @@ The ADOT Collector includes two AWS OpenTelemetry Collector components specific 
 ### Create EKS on EC2 cluster
 
 Our demo application in this recipe will be running on top of EKS. 
-You can either use an existing EKS cluster or create one using [cluster_config.yaml](./ec2-eks-metrics-go-adot-ampamg/cluster-config.yaml).
+You can either use an existing EKS cluster or create one using [cluster-config.yaml](./ec2-eks-metrics-go-adot-ampamg/cluster-config.yaml).
 
 This template will create a new cluster with two EC2 `t2.large` nodes. 
 

--- a/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/ec2-eks-metrics-go-adot-ampamg.md
@@ -59,6 +59,7 @@ eksctl create cluster -f cluster-config.yaml
 
 In order to deploy our application to EKS we need a container registry. 
 You can use the following command to create a new ECR registry in your account. 
+Make sure to set `<YOUR_REGION>` as well.
 
 ```
 aws ecr create-repository \

--- a/docs/recipes/ec2-eks-metrics-go-adot-ampamg/adot-collector-ec2.yaml
+++ b/docs/recipes/ec2-eks-metrics-go-adot-ampamg/adot-collector-ec2.yaml
@@ -25,11 +25,11 @@ data:
               regex: true
     exporters:
       awsprometheusremotewrite:
-        # replace this with your endpoint:
-        endpoint: "YOUR_ENDPOINT"
+        # replace this with your endpoint, in double quotes:
+        endpoint: <YOUR_ENDPOINT>
         aws_auth:
-          # replace this with your region:
-          region: "YOUR_REGION"
+          # replace this with your region, in double quotes:
+          region: <YOUR_REGION>
           service: "aps"
       logging:
         loglevel: debug

--- a/docs/recipes/ec2-eks-metrics-go-adot-ampamg/cluster-config.yaml
+++ b/docs/recipes/ec2-eks-metrics-go-adot-ampamg/cluster-config.yaml
@@ -3,7 +3,7 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
   name: amp-eks-ec2
-  region: eu-west-1
+  region: <YOUR_REGION>
   version: '1.21'
 iam:
   withOIDC: true

--- a/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
@@ -65,13 +65,14 @@ eksctl create cluster -f cluster-config.yaml
 ### Create ECR repository
 
 In order to deploy our application to EKS we need a container repository. 
-You can use the following command to create a new ECR repository in your account: 
+You can use the following command to create a new ECR repository in your account.
+Make sure to set `<YOUR_REGION>` as well.
 
 ```
 aws ecr create-repository \
     --repository-name prometheus-sample-app \
     --image-scanning-configuration scanOnPush=true \
-    --region eu-west-1
+    --region <YOUR_REGION>
 ```
 
 ### Set up AMP

--- a/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
@@ -47,13 +47,13 @@ The ADOT Collector includes two components specific to Prometheus:
 Our demo application is a Kubernetes app that we will run in an EKS on Fargate
 cluster. So, first create an EKS cluster using the
 provided [cluster-config.yaml](./fargate-eks-metrics-go-adot-ampamg/cluster-config.yaml)
-template file by changing your region to one of the
+template file by changing `<YOUR_REGION>` to one of the
 [supported regions for AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html#AMP-supported-Regions).
 
-Make sure to set your region in your shell session, for example, in Bash:
+Make sure to set `<YOUR_REGION>` in your shell session, for example, in Bash:
 
 ```
-export AWS_DEFAULT_REGION=eu-west-1
+export AWS_DEFAULT_REGION=<YOUR_REGION>
 ```
 
 Create your cluster using the following command:
@@ -104,7 +104,7 @@ You can remove this from the re-label configurations if you want to scrape a dif
 
 Use the following steps to edit the downloaded file for your environment:
 
-1\. Replace `<REGION>` with your current region. 
+1\. Replace `<YOUR_REGION>` with your current region. 
 
 2\. Replace `<YOUR_ENDPOINT>` with the remote write URL of your workspace.
 

--- a/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
+++ b/docs/recipes/fargate-eks-metrics-go-adot-ampamg.md
@@ -46,7 +46,7 @@ The ADOT Collector includes two components specific to Prometheus:
 
 Our demo application is a Kubernetes app that we will run in an EKS on Fargate
 cluster. So, first create an EKS cluster using the
-provided [cluster_config.yaml](./fargate-eks-metrics-go-adot-ampamg/cluster-config.yaml)
+provided [cluster-config.yaml](./fargate-eks-metrics-go-adot-ampamg/cluster-config.yaml)
 template file by changing your region to one of the
 [supported regions for AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html#AMP-supported-Regions).
 

--- a/docs/recipes/fargate-eks-metrics-go-adot-ampamg/adot-collector-fargate.yaml
+++ b/docs/recipes/fargate-eks-metrics-go-adot-ampamg/adot-collector-fargate.yaml
@@ -25,11 +25,11 @@ data:
               regex: true
     exporters:
       awsprometheusremotewrite:
-        # replace this with your endpoint:
-        endpoint: "YOUR_ENDPOINT"
+        # replace this with your endpoint, in double quotes:
+        endpoint: <YOUR_ENDPOINT>
         aws_auth:
-          # replace this with your region:
-          region: "YOUR_REGION"
+          # replace this with your region, in double quotes:
+          region: <YOUR_REGION>
           service: "aps"
       logging:
         loglevel: debug

--- a/docs/recipes/fargate-eks-metrics-go-adot-ampamg/cluster-config.yaml
+++ b/docs/recipes/fargate-eks-metrics-go-adot-ampamg/cluster-config.yaml
@@ -3,7 +3,7 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
   name: amp-eks-fargate
-  region: eu-west-1
+  region: <YOUR_REGION>
   version: '1.21'
 iam:
   withOIDC: true


### PR DESCRIPTION
This PR addresses issue #21 and generalizes region use in the ADOT on EKS with Fargate/EC2 to AMP recipes. 