### PR TITLE
Add AWS App Runner recipes

### DIFF
--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -8,15 +8,6 @@ App Runner provides you with a service URL that receives HTTPS requests to your 
 
 Check out the following recipes:
 
-## Traces
-- [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
-- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
-- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
-- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
-- [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
-- [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
-
-
 ## Logs
 
 - [Viewing App Runner logs streamed to CloudWatch Logs][apprunner-cwl]
@@ -25,6 +16,13 @@ Check out the following recipes:
 
 - [Viewing App Runner service metrics reported to CloudWatch](apprunner-cwm)
 
+## Traces
+- [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
+- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
+- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
+- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
+- [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
+- [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
 
 
 [apprunner-main]: https://aws.amazon.com/apprunner/

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -15,6 +15,7 @@ Check out the following recipes:
 ## Metrics
 
 - [Viewing App Runner service metrics reported to CloudWatch](apprunner-cwm)
+- [AWS Blog | Centralized observability for AWS App Runner services](https://aws.amazon.com/blogs/containers/centralized-observability-for-aws-app-runner-services/)
 
 ## Traces
 - [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -10,11 +10,11 @@ Check out the following recipes:
 
 ## Traces
 - [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
+- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
+- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
+- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
 - [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
 - [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
-- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
-- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
-- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
 
 
 ## Logs

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -1,0 +1,32 @@
+# AWS App Runner
+
+[AWS App Runner][apprunner-main] is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs at scale and with little to no infrastructure experience. 
+You can start with your source code or a container image, and App Runner will fully manage all infrastructure including servers, networking, and load balancing for your application. 
+App Runner provides you with a service URL that receives HTTPS requests to your application. As an option, App Runner can also configure a continuous deployment pipeline for you.
+
+
+
+Check out the following recipes:
+
+## Traces
+- [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
+- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
+- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
+- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
+
+
+## Logs
+
+- [Viewing App Runner logs streamed to CloudWatch Logs][apprunner-cwl]
+
+## Metrics
+
+- [Viewing App Runner service metrics reported to CloudWatch](apprunner-cwm)
+
+
+
+[apprunner-main]: https://aws.amazon.com/apprunner/
+[aes-ws]: https://bookstore.aesworkshops.com/
+[apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
+[apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
+[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -10,6 +10,8 @@ Check out the following recipes:
 
 ## Traces
 - [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
+- [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
+- [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
 - [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
 - [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
 - [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The way we think about the o11y space is as follows: we decompose it into
 | agents        | [ADOT][adot] &middot; [Fluent Bit][fluentbit] &middot; CW agent &middot; X-Ray agent |
 | languages     | [Java][java] &middot; Python &middot; .NET &middot; [JavaScript][nodejs] &middot; Go &middot; Rust |
 | infra & databases  |  [RDS][rds] &middot; [DynamoDB][dynamodb] &middot; [MSK][msk] |
-| compute unit | [Batch][batch] &middot; [ECS][ecs] &middot; [EKS][eks] &middot; [AEB][beans] &middot; [Lambda][lambda] |
+| compute unit | [Batch][batch] &middot; [ECS][ecs] &middot; [EKS][eks] &middot; [AEB][beans] &middot; [Lambda][lambda] &middot; [AppRunner][apprunner] |
 | compute engine | [Fargate][fargate] &middot; [EC2][ec2] &middot; [Lightsail][lightsail] |
 
 For example, you might be looking for a solution to:
@@ -94,6 +94,7 @@ check out:
 [fluentbit]: https://fluentbit.io/ "Fluent Bit"
 [jaeger]: https://www.jaegertracing.io/ "Jaeger"
 [kafka]: https://kafka.apache.org/ "Apache Kafka"
+[apprunner]: apprunner.md "AWS App Runner"
 [lambda]: lambda.md "AWS Lambda"
 [lightsail]: https://aws.amazon.com/lightsail/ "Amazon Lightsail"
 [otel]: https://opentelemetry.io/ "OpenTelemetry"

--- a/docs/workshops.md
+++ b/docs/workshops.md
@@ -6,3 +6,4 @@ and demonstrations around o11y systems and tooling.
 - [One Observability Workshop](https://observability.workshop.aws/en/)
 - [EKS Workshop](https://www.eksworkshop.com/)
 - [ECS Workshop](https://www.ecsworkshop.com/)
+- [App Runner Workshop](https://www.apprunnerworkshop.com/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - dimensions.md
   - telemetry.md
 - 'By Compute':
+  - apprunner.md
   - eks.md
   - ecs.md
   - lambda.md


### PR DESCRIPTION
Add AWS App Runner recipes

### Test detail:

```
yimipeng@f4d488b5653f aws-o11y-recipes % mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  The following pages exist in the docs directory, but are not
            included in the "nav" configuration:
              - recipes/amg-athena-plugin.md
              - recipes/amg-automation-tf.md
              - recipes/amg-google-auth-saml.md
              - recipes/amg-redshift-plugin.md
              - recipes/amp-alertmanager-terraform.md
              - recipes/ec2-eks-metrics-go-adot-ampamg.md
              - recipes/fargate-eks-metrics-go-adot-ampamg.md
              - recipes/fargate-eks-xray-go-adot-amg.md
              - recipes/lambda-cw-metrics-go-amp.md
              - recipes/monitoring-hybridenv-amg.md
              - recipes/servicemesh-monitoring-ampamg.md
INFO     -  Documentation built in 0.33 seconds
INFO     -  [10:46:16] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO     -  [10:46:16] Serving on http://127.0.0.1:8000/aws-o11y-recipes/
INFO     -  [10:46:31] Browser connected:
            http://127.0.0.1:8000/aws-o11y-recipes/
INFO     -  [10:47:31] Browser connected:
            http://127.0.0.1:8000/aws-o11y-recipes/apprunner/
```