### PR TITLE
Nit updates on AppRunner recipes content

### DIFF
--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -33,4 +33,4 @@ Check out the following recipes:
 [aes-ws]: https://bookstore.aesworkshops.com/
 [apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
 [apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
-[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner.html
+[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -24,7 +24,7 @@ Check out the following recipes:
 
 
 ## Traces
-- [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
+- [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](https://aws-otel.github.io/docs/getting-started/apprunner)
 - [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
 - [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
 - [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
@@ -33,4 +33,3 @@ Check out the following recipes:
 [aes-ws]: https://bookstore.aesworkshops.com/
 [apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
 [apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
-[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/using-ecs-console-for-ecs-adot-observability

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -1,9 +1,6 @@
 # AWS App Runner
 
-[AWS App Runner][apprunner-main] is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs at scale and with little to no infrastructure experience. 
-You can start with your source code or a container image, and App Runner will fully manage all infrastructure including servers, networking, and load balancing for your application. 
-App Runner provides you with a service URL that receives HTTPS requests to your application. As an option, App Runner can also configure a continuous deployment pipeline for you.
-
+[AWS App Runner][apprunner-main] is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs, at scale and with no prior infrastructure experience required. Start with your source code or a container image. App Runner builds and deploys the web application automatically, load balances traffic with encryption, scales to meet your traffic needs, and makes it easy for your services to communicate with other AWS services and applications that run in a private Amazon VPC. With App Runner, rather than thinking about servers or scaling, you have more time to focus on your applications.
 
 
 Check out the following recipes:

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -33,4 +33,4 @@ Check out the following recipes:
 [aes-ws]: https://bookstore.aesworkshops.com/
 [apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
 [apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
-[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner
+[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner/

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -33,4 +33,4 @@ Check out the following recipes:
 [aes-ws]: https://bookstore.aesworkshops.com/
 [apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
 [apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
-[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner/
+[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/using-ecs-console-for-ecs-adot-observability

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -3,6 +3,8 @@
 [AWS App Runner][apprunner-main] is a fully managed service that makes it easy for developers to quickly deploy containerized web applications and APIs, at scale and with no prior infrastructure experience required. Start with your source code or a container image. App Runner builds and deploys the web application automatically, load balances traffic with encryption, scales to meet your traffic needs, and makes it easy for your services to communicate with other AWS services and applications that run in a private Amazon VPC. With App Runner, rather than thinking about servers or scaling, you have more time to focus on your applications.
 
 
+
+
 Check out the following recipes:
 
 ## General

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -12,6 +12,7 @@ Check out the following recipes:
 - [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
 - [AWS Blog | Centralized observability for AWS App Runner services](https://aws.amazon.com/blogs/containers/centralized-observability-for-aws-app-runner-services/)
 - [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
+- [AWS Blog | Controlling and monitoring AWS App Runner applications with Amazon EventBridge](https://aws.amazon.com/blogs/containers/controlling-and-monitoring-aws-app-runner-applications-with-amazon-eventbridge/)
 
 
 ## Logs

--- a/docs/apprunner.md
+++ b/docs/apprunner.md
@@ -8,6 +8,12 @@ App Runner provides you with a service URL that receives HTTPS requests to your 
 
 Check out the following recipes:
 
+## General
+- [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
+- [AWS Blog | Centralized observability for AWS App Runner services](https://aws.amazon.com/blogs/containers/centralized-observability-for-aws-app-runner-services/)
+- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
+
+
 ## Logs
 
 - [Viewing App Runner logs streamed to CloudWatch Logs][apprunner-cwl]
@@ -15,19 +21,16 @@ Check out the following recipes:
 ## Metrics
 
 - [Viewing App Runner service metrics reported to CloudWatch](apprunner-cwm)
-- [AWS Blog | Centralized observability for AWS App Runner services](https://aws.amazon.com/blogs/containers/centralized-observability-for-aws-app-runner-services/)
+
 
 ## Traces
 - [Getting Started with AWS X-Ray tracing for App Runner using AWS Distro for OpenTelemetry](apprunner-xray-adot)
-- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
-- [AWS Blog | Observability for AWS App Runner VPC networking](https://aws.amazon.com/blogs/containers/observability-for-aws-app-runner-vpc-networking/)
-- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
-- [Container Day - Docker Con | How Developers can get to production web applications at scale easily](https://www.youtube.com/watch?v=Iyp9Ugk9oRs)
 - [Containers from the Couch | AWS App Runner X-Ray Integration](https://youtu.be/cVr8N7enCMM)
-
+- [AWS Blog | Tracing an AWS App Runner service using AWS X-Ray with OpenTelemetry](https://aws.amazon.com/blogs/containers/tracing-an-aws-app-runner-service-using-aws-x-ray-with-opentelemetry/)
+- [AWS Blog | Enabling AWS X-Ray tracing for AWS App Runner service using AWS Copilot CLI](https://aws.amazon.com/blogs/containers/enabling-aws-x-ray-tracing-for-aws-app-runner-service-using-aws-copilot-cli/)
 
 [apprunner-main]: https://aws.amazon.com/apprunner/
 [aes-ws]: https://bookstore.aesworkshops.com/
 [apprunner-cwl]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cwl.html
 [apprunner-cwm]: https://docs.aws.amazon.com/apprunner/latest/dg/monitor-cw.html
-[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner
+[apprunner-xray-adot]: https://aws-otel.github.io/docs/getting-started/apprunner.html


### PR DESCRIPTION
### Description
Nit updates on AppRunner recipes content. Fix one broken link. 

### Test Detail
```
yimipeng@f4d488b5653f aws-o11y-recipes % mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
INFO     -  The following pages exist in the docs directory, but are not
            included in the "nav" configuration:
              - recipes/amg-athena-plugin.md
              - recipes/amg-automation-tf.md
              - recipes/amg-google-auth-saml.md
              - recipes/amg-redshift-plugin.md
              - recipes/amp-alertmanager-terraform.md
              - recipes/ec2-eks-metrics-go-adot-ampamg.md
              - recipes/fargate-eks-metrics-go-adot-ampamg.md
              - recipes/fargate-eks-xray-go-adot-amg.md
              - recipes/lambda-cw-metrics-go-amp.md
              - recipes/monitoring-hybridenv-amg.md
              - recipes/servicemesh-monitoring-ampamg.md
INFO     -  Documentation built in 0.35 seconds
INFO     -  [12:54:06] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO     -  [12:54:06] Serving on http://127.0.0.1:8000/aws-o11y-recipes/
INFO     -  [12:54:12] Browser connected:
            http://127.0.0.1:8000/aws-o11y-recipes/
```