### PR TITLE
Updated client version

### DIFF
--- a/sandbox/ho11y/go.mod
+++ b/sandbox/ho11y/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 // indirect
 	github.com/catalint/datasize v0.0.0-20160514201228-ac35299842b2
 	github.com/gorilla/mux v1.8.0
-	github.com/prometheus/client_golang v1.10.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.18.0


### PR DESCRIPTION
You get this error while building,
[build 7/7] RUN CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"': #15 141.8 go: github.com/prometheus/client_golang@v1.10.0 requires
#15 141.8       github.com/prometheus/common@v0.18.0 requires
#15 141.8 	github.com/go-kit/kit@v0.10.0 requires
#15 141.8 	github.com/nats-io/nats.go@v1.9.1: reading github.com/nats-io/nats.go/go.mod at revision v1.9.1: unknown revision v1.9.1

Version needs to be updated to 1.14.0 which does not have any dependency on nats.go.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

